### PR TITLE
Fix distribution with mask over a period with  less event than UTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.6 (2021/03/26)
+
+* added new MarkPeriods function to merge periods into new UTS
+* fixed distribution when the mask has more defined events than base UTS
+
 # v0.1.5 (2020/10/14)
 
 * added DumpBufferWithPrefix function

--- a/distribution.go
+++ b/distribution.go
@@ -14,11 +14,11 @@ func (uts *USTimeSerie) Distribution(start time.Time, end time.Time, mask *USTim
 	ret := make(map[interface{}]time.Duration)
 	ilog.Debugf(">>>>USTS DEBUG [USTimeSerie:Distribution]: start/end [%s/%s] \n", start, end)
 
+	// if mask is not provided, we setup as default over all available period as true
 	if mask == nil {
-
 		mask = NewUSTimeSerie(0)
 		mask.SetDefault(true)
-
+		mask.SetIntervalValue(start, end, true)
 	}
 
 	//Distribution needs to have defined elements on exact start/end
@@ -33,9 +33,19 @@ func (uts *USTimeSerie) Distribution(start time.Time, end time.Time, mask *USTim
 		cloned.Insert(end, sEnd)
 	}
 
+	// Distribution needs to create a new UST with all available events during time
+	// logically: cloned && mask will create C cloned periods + M mask periods
+	clonedMarked, err := cloned.MarkPeriods(mask)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// The logical operation mask && cloned can return nil if mask is not defined
+	// in this case, we will use directly the cloned one
+
 	mask.IterateOnPeriods(start, end, true,
 		func(tm0, tm1 time.Time, valmask interface{}) bool {
-			cloned.IterateOnPeriods(tm0, tm1, nil,
+			clonedMarked.IterateOnPeriods(tm0, tm1, nil,
 				func(t0, t1 time.Time, val interface{}) bool {
 					dur := t1.Sub(t0)
 					tdur += dur

--- a/operators.go
+++ b/operators.go
@@ -122,6 +122,35 @@ func (uts *USTimeSerie) And(other *USTimeSerie) (*USTimeSerie, error) {
 	return res, nil
 }
 
+// Mark periods on this TimeSerie with the other TimeSerie the resulting
+// TimeSerie will have the same time points of this TimeSeries (max will be N+M if any repeated time)
+// with all available periods of this TimeSerie and the other TimeSerie (max will be N+M periods)
+// marking periods: this is `output[t] = x[t1..tM]` with M all available time periods combinations,
+// if x[tx] has no value, it will retrieve the previous
+func (uts *USTimeSerie) MarkPeriods(other *USTimeSerie) (*USTimeSerie, error) {
+
+	var res *USTimeSerie
+
+	if uts.Len() == 0 {
+		res = NewUSTimeSerie(0)
+		res.SetDefault(uts.defVal)
+		return res, nil
+	}
+
+	combined := unique(keyCombineOrdered(uts.Keys(), other.Keys()))
+
+	res = NewUSTimeSerie(len(combined))
+	res.SetDefault(uts.defVal)
+
+	for _, t := range combined {
+		v1, _ := uts.Get(t)
+		ilog.Debugf(">>>>USTS DEBUG [USTimeSerie:MarkPeriods]:marking periods with value for time %s [ %+v ]", t, v1)
+		result := v1
+		res.Add(t, result)
+	}
+	return res, nil
+}
+
 // Or Logical OR from this TimeSerie with the other TimeSerie the resulting
 // TimeSerie will have the same time points in both previous series (max will be N+M if any repeated time)
 // computing logical OR : this is `output[t] = x[t1] OR y[t1]` if no value in y[t1] it gets the previous value


### PR DESCRIPTION
When a distributions is done, if the applied mask has less events than
the TS over the period is defined the results may be wrong

This PR fixes applying a new function MarkPeriod that is applied directly on the
cloned UTS to mark in time the periods where mask shold be applied