### PR TITLE
Fix USTS index getter when the events are outside the usts period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.7 (2021/03/29)
+
+* fixed usts index getter when the events are outside the using timeref period (start/end)
+
 # v0.1.6 (2021/03/26)
 
 * added new MarkPeriods function to merge periods into new UTS

--- a/distribution_test.go
+++ b/distribution_test.go
@@ -469,3 +469,164 @@ func ExampleDistribution_EventsUTS_Mask() {
 	// VALUE true present for 15m0s :  30.00 %
 	// VALUE false present for 35m0s :  70.00 %
 }
+
+func ExampleDistribution_EventsUTS_MaskOverSubTime() {
+	var err error
+	var t0, t1 time.Time
+	var total time.Duration
+	var totalsec int64
+	var m map[interface{}]time.Duration
+
+	// TS - UTS with events
+	// |--______-------------______-----------------| - 1h
+
+	ts := NewUSTimeSerie(0)
+	ts.SetDefault(true)
+	// Add values to default
+	ts.Add(time.Date(2021, 03, 24, 14, 05, 0, 0, time.UTC), false)
+	ts.Add(time.Date(2021, 03, 24, 14, 50, 0, 0, time.UTC), true)
+
+	// MASK - UTS with false values on an specific interval
+	// |----_______---------------------------------| - 1h
+
+	tm0 := time.Date(2021, 03, 24, 13, 30, 0, 0, time.UTC)
+	tm1 := time.Date(2021, 03, 24, 14, 30, 0, 0, time.UTC)
+	mask := NewUSTimeSerie(0)
+	mask.SetDefault(true)
+	mask.SetIntervalValue(tm0, tm1, false)
+
+	// EXPECTED DISTRIBUTION
+	// t1 = 14:00-14:05 | True	|
+	// t2 = 14:05-14:10 | False	|
+	// t3 = 14:10-14:15 | False | X (Masked)
+	// t4 = 14:15-14:20 | True 	| X (Masked)
+	// t5 = 14:20-14:30 | True	|
+	// t6 = 14:30-15:00 | False |
+	// |t1*t2*t3*t4*     t5    *        t6          |
+	// |--___|__---|------------____________________| - 1h
+	// |--___|     |------------____________________| - 50m
+
+	t0 = time.Date(2021, 03, 24, 14, 00, 0, 0, time.UTC)
+	t1 = time.Date(2021, 03, 24, 15, 00, 0, 0, time.UTC)
+
+	m, total, err = ts.Distribution(t0, t1, mask)
+	if err != nil {
+		fmt.Errorf("Error: %s", err)
+		return
+	}
+	totalsec = int64(total / time.Second)
+
+	for k, v := range m {
+		percent := float64(v/time.Second) * 100.0 / float64(totalsec)
+		fmt.Printf("VALUE %v present for %s :  %.2f %%\n", k, v, percent)
+	}
+
+	// Unordered output:
+	// VALUE false present for 20m0s :  66.67 %
+	// VALUE true present for 10m0s :  33.33 %
+}
+
+func ExampleDistribution_EventsUTS_MaskOverSupTime() {
+	var err error
+	var t0, t1 time.Time
+	var total time.Duration
+	var totalsec int64
+	var m map[interface{}]time.Duration
+
+	// TS - UTS with events
+	// |--_________________________________---------| - 1h
+
+	ts := NewUSTimeSerie(0)
+	ts.SetDefault(true)
+	// Add values to default
+	ts.Add(time.Date(2021, 03, 24, 14, 05, 0, 0, time.UTC), false)
+	ts.Add(time.Date(2021, 03, 24, 14, 50, 0, 0, time.UTC), true)
+
+	// MASK - UTS with false values on an specific interval
+	// |------------------------____________________| - 1h
+
+	tm0 := time.Date(2021, 03, 24, 14, 30, 0, 0, time.UTC)
+	tm1 := time.Date(2021, 03, 24, 15, 30, 0, 0, time.UTC)
+	mask := NewUSTimeSerie(0)
+	mask.SetDefault(true)
+	mask.SetIntervalValue(tm0, tm1, false)
+
+	// EXPECTED DISTRIBUTION
+	// t1 = 14:00-14:05 | True	|
+	// t2 = 14:05-14:30 | False	|
+	// t3 = 14:30-14:50 | False | Masked
+	// t4 = 14:50-15:00 | True 	| Masked
+	// |t1*      t2    *        t3          * t4    |
+	// |--_________________|_________________-------| - 1h
+	// |--_________________|________________________| - 30m
+
+	t0 = time.Date(2021, 03, 24, 14, 00, 0, 0, time.UTC)
+	t1 = time.Date(2021, 03, 24, 15, 00, 0, 0, time.UTC)
+
+	m, total, err = ts.Distribution(t0, t1, mask)
+	if err != nil {
+		fmt.Errorf("Error: %s", err)
+		return
+	}
+	totalsec = int64(total / time.Second)
+
+	for k, v := range m {
+		percent := float64(v/time.Second) * 100.0 / float64(totalsec)
+		fmt.Printf("VALUE %v present for %s :  %.2f %%\n", k, v, percent)
+	}
+
+	// Unordered output:
+	// VALUE true present for 5m0s :  16.67 %
+	// VALUE false present for 25m0s :  83.33 %
+}
+
+func ExampleDistribution_EventsUTS_MaskOverSubSupTime() {
+	var err error
+	var t0, t1 time.Time
+	var total time.Duration
+	var totalsec int64
+	var m map[interface{}]time.Duration
+
+	// TS - UTS with events
+	// |--_________________________________---------| - 1h
+
+	ts := NewUSTimeSerie(0)
+	ts.SetDefault(true)
+	// Add values to default
+	ts.Add(time.Date(2021, 03, 24, 14, 05, 0, 0, time.UTC), false)
+	ts.Add(time.Date(2021, 03, 24, 14, 50, 0, 0, time.UTC), true)
+
+	// MASK - UTS with false values on an specific interval
+	// |----_______---------------------------------| - 1h
+
+	tm0 := time.Date(2021, 03, 24, 13, 30, 0, 0, time.UTC)
+	tm1 := time.Date(2021, 03, 24, 15, 30, 0, 0, time.UTC)
+	mask := NewUSTimeSerie(0)
+	mask.SetDefault(true)
+	mask.SetIntervalValue(tm0, tm1, false)
+
+	// EXPECTED DISTRIBUTION
+	// t1 = 14:00-14:05 | True	| Masked
+	// t2 = 14:05-14:50 | False	| Masked
+	// t3 = 14:50-15:00 | True 	| Masked
+	// |t1*        t2                       *   t3  |
+	// |--___________________________________-------| - 1h
+	// |--___________________________________-------| - 0
+
+	t0 = time.Date(2021, 03, 24, 14, 00, 0, 0, time.UTC)
+	t1 = time.Date(2021, 03, 24, 15, 00, 0, 0, time.UTC)
+
+	m, total, err = ts.Distribution(t0, t1, mask)
+	if err != nil {
+		fmt.Errorf("Error: %s", err)
+		return
+	}
+	totalsec = int64(total / time.Second)
+
+	for k, v := range m {
+		percent := float64(v/time.Second) * 100.0 / float64(totalsec)
+		fmt.Printf("VALUE %v present for %s :  %.2f %%\n", k, v, percent)
+	}
+
+	// Unordered output:
+}

--- a/timeseries.go
+++ b/timeseries.go
@@ -163,6 +163,7 @@ func (uts *USTimeSerie) getLeftRightIndexInsidePeriod(start, end time.Time) (int
 	ilog.Debugf(">>>>USTS DEBUG [USTimeSerie:getLeftRightIndexInsidePeriod]:>>>>START ---> %d\n", s)
 	//End
 	t = end
+	bf := false
 	for k, v := range uts.t {
 		ilog.Tracef(">>>>USTS TRACE [USTimeSerie:getLeftRightIndexInsidePeriod]: END[%d]-----[%s]------->[%s]\n", k, t, v)
 		if t.Equal(v) {
@@ -171,10 +172,19 @@ func (uts *USTimeSerie) getLeftRightIndexInsidePeriod(start, end time.Time) (int
 		}
 		if t.Before(v) {
 			e = k - 1
+			bf = true
 			break
 		}
 	}
 	ilog.Tracef(">>>>USTS TRACE [USTimeSerie:getLeftRightIndexInsidePeriod]: S[%d] E[%d]\n", s, e)
+
+	// if the end is the first index, means that no period is equal or before than the provided t
+	// in this case, a single event is xpected on s/e
+	// TODO: review if it fits all the cases
+	if e == 0 && !bf {
+		e = len(uts.t) - 1
+	}
+
 	//TODO: this condition is not always true... should be reviewed
 	if e < s && s-e == 1 {
 		//complete period inside 2 consecutive points
@@ -182,9 +192,7 @@ func (uts *USTimeSerie) getLeftRightIndexInsidePeriod(start, end time.Time) (int
 		ilog.Tracef(">>>>USTS TRACE [USTimeSerie:getLeftRightIndexInsidePeriod]: Swapping Start/End values now START %d and END %d\n", e, s)
 		return e, s, fmt.Errorf("Period inside two consecutive points")
 	}
-	if e == 0 {
-		e = len(uts.t) - 1
-	}
+
 	ilog.Debugf(">>>>USTS DEBUG [USTimeSerie:getLeftRightIndexInsidePeriod]: START %d / END %d\n", s, e)
 	return s, e, nil
 }

--- a/timeseries_test.go
+++ b/timeseries_test.go
@@ -356,6 +356,56 @@ func ExampleIterateNormal() {
 
 }
 
+func ExampleIterateNorma_SubEvents() {
+	ts := NewUSTimeSerie(0)
+	ts.SetInitialVal(false)
+
+	// Insert example records:
+	ts.Add(time.Date(2021, 03, 24, 16, 30, 0, 0, time.UTC), true)
+	ts.Add(time.Date(2021, 03, 24, 17, 30, 0, 0, time.UTC), false)
+
+	start := time.Date(2021, 03, 24, 17, 0, 0, 0, time.UTC)
+	end := time.Date(2021, 03, 24, 18, 0, 0, 0, time.UTC)
+
+	//end := time.Now()
+
+	err := ts.Iterate(false, start, end, func(t time.Time, val interface{}, i int) bool {
+		fmt.Printf("[%d] TIME: %s : VALUE %v\n", i, t, val)
+		return true
+	})
+	if err != nil {
+		fmt.Printf("Error : %s", err)
+	}
+	// Output:
+	// [1] TIME: 2021-03-24 17:30:00 +0000 UTC : VALUE false
+
+}
+
+func ExampleIterateNorma_SupEvents() {
+	ts := NewUSTimeSerie(0)
+	ts.SetInitialVal(false)
+
+	// Insert example records:
+	ts.Add(time.Date(2021, 03, 24, 17, 30, 0, 0, time.UTC), false)
+	ts.Add(time.Date(2021, 03, 24, 18, 30, 0, 0, time.UTC), true)
+
+	start := time.Date(2021, 03, 24, 17, 0, 0, 0, time.UTC)
+	end := time.Date(2021, 03, 24, 18, 0, 0, 0, time.UTC)
+
+	//end := time.Now()
+
+	err := ts.Iterate(false, start, end, func(t time.Time, val interface{}, i int) bool {
+		fmt.Printf("[%d] TIME: %s : VALUE %v\n", i, t, val)
+		return true
+	})
+	if err != nil {
+		fmt.Printf("Error : %s", err)
+	}
+	// Output:
+	// [0] TIME: 2021-03-24 17:30:00 +0000 UTC : VALUE false
+
+}
+
 func ExampleIterateReverse() {
 	ts := NewUSTimeSerie(0)
 


### PR DESCRIPTION
When the events are outside the utsts period the iterate functions could
give wrong results based on the number of events on the period

This PR tries to fix the distribution core function and the iterate
function modifying the logic of the core function `getLeftRightIndexInsidePeriod`