### PR TITLE
Fix GetTimeEvents func when the events were less than 1h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.9 (2021/04/12)
+
+* fixed GetTimeEvents func when the events were less than 1h, now a precision of milliseconds is supported
+
 # v0.1.8 (2021/03/31)
 
 * added CompactBoundaries function to retrieve min/max boundaries of repeated events on USTs

--- a/timeslot.go
+++ b/timeslot.go
@@ -71,11 +71,14 @@ func (ts *TimeSlot) RefreshCronTZ(tz string) error {
 
 // GetPreviousCronTime get Previous scheduled time from cron Scheduler
 // this method will check if exist any previous sched value beggining in the past
-// in order to avoid too expensive cost we will test iteratively with 1h,6h,24h,7d,30d,365d before
+// with different intervals 1ms,1s,1m,1h,6h,24h,7d,30d,365d before
 func GetPreviousCronTime(sch cron.Schedule, start time.Time) time.Time {
 
 	intervals := []time.Duration{
-		time.Hour,            //1h
+		1 * time.Millisecond, //1ms
+		1 * time.Second,      //1s
+		1 * time.Minute,      //1m
+		1 * time.Hour,        //1h
 		6 * time.Hour,        //6h
 		24 * time.Hour,       //24h
 		7 * 24 * time.Hour,   //7d

--- a/timewindow_test.go
+++ b/timewindow_test.go
@@ -309,3 +309,150 @@ func ExampleTimeWindow_6() {
 	//[INIT] Default VALUE: false
 	//[0] TIME: 2020-04-27 18:00:00 +0200 CEST | VALUE: false
 }
+
+func ExampleTimeWindow_7() {
+
+	var ts *USTimeSerie
+	var err error
+	var loc *time.Location
+	var slot *TimeSlot
+
+	win := NewTimeWindow("8x5")
+	loc, err = win.SetTimeZone("Europe/Madrid")
+	if err != nil {
+		fmt.Printf("ERROR on set timeZone %s\n", err)
+		return
+	}
+
+	slot, err = NewTimeSlot("8x5_a", "00 09 * * *", "00 14 * * *")
+	if err != nil {
+		fmt.Printf("ERROR on get slot 24x5 %s\n", err)
+		return
+	}
+	win.AddSlot(slot, Add)
+
+	slot, err = NewTimeSlot("8x5_b", "00 16 * * MON-FRI", "00 20 * * MON-FRI")
+	if err != nil {
+		fmt.Printf("ERROR on get slot  mon_6_to_8 %s\n", err)
+		return
+	}
+	win.AddSlot(slot, Add)
+
+	t0 := time.Date(2020, 4, 27, 14, 30, 0, 0, loc)
+	t1 := time.Date(2020, 4, 27, 14, 30, 0, 0, loc)
+
+	ts, err = win.GetTimeEvents(t0, t1)
+	if err != nil {
+		fmt.Printf("ERROR on set timewindow %s\n", err)
+		return
+	}
+	ts.DumpInTimezone("Europe/Madrid")
+	// Output:
+	//[INIT] Default VALUE: false
+}
+
+func ExampleTimeWindow_8() {
+
+	var ts *USTimeSerie
+	var err error
+	var loc *time.Location
+	var slot *TimeSlot
+
+	win := NewTimeWindow("8x5")
+	loc, err = win.SetTimeZone("Europe/Madrid")
+	if err != nil {
+		fmt.Printf("ERROR on set timeZone %s\n", err)
+		return
+	}
+
+	slot, err = NewTimeSlot("8x5_a", "00 09 * * *", "00 14 * * *")
+	if err != nil {
+		fmt.Printf("ERROR on get slot 24x5 %s\n", err)
+		return
+	}
+	win.AddSlot(slot, Add)
+
+	slot, err = NewTimeSlot("8x5_b", "00 16 * * MON-FRI", "00 20 * * MON-FRI")
+	if err != nil {
+		fmt.Printf("ERROR on get slot  mon_6_to_8 %s\n", err)
+		return
+	}
+	win.AddSlot(slot, Add)
+
+	t0 := time.Date(2020, 4, 27, 15, 05, 0, 0, loc)
+	t1 := time.Date(2020, 4, 27, 15, 15, 0, 0, loc)
+
+	ts, err = win.GetTimeEvents(t0, t1)
+	if err != nil {
+		fmt.Printf("ERROR on set timewindow %s\n", err)
+		return
+	}
+	ts.DumpInTimezone("Europe/Madrid")
+	// Output:
+	//[INIT] Default VALUE: false
+}
+
+func ExampleTimeWindow_9() {
+
+	var ts *USTimeSerie
+	var err error
+	var loc *time.Location
+	var slot *TimeSlot
+
+	win := NewTimeWindow("8x5")
+	loc, err = win.SetTimeZone("Europe/Madrid")
+	if err != nil {
+		fmt.Printf("ERROR on set timeZone %s\n", err)
+		return
+	}
+
+	slot, err = NewTimeSlot("8x5_a", "15 09 * * *", "30 14 * * *")
+	if err != nil {
+		fmt.Printf("ERROR on get slot 24x5 %s\n", err)
+		return
+	}
+	win.AddSlot(slot, Add)
+
+	slot, err = NewTimeSlot("8x5_b", "20 16 * * MON-FRI", "40 20 * * MON-FRI")
+	if err != nil {
+		fmt.Printf("ERROR on get slot  mon_6_to_8 %s\n", err)
+		return
+	}
+	win.AddSlot(slot, Add)
+
+	t0 := time.Date(2020, 4, 27, 9, 14, 59, 0, loc)
+	t1 := time.Date(2020, 4, 27, 9, 14, 59, 0, loc)
+
+	ts, err = win.GetTimeEvents(t0, t1)
+	if err != nil {
+		fmt.Printf("ERROR on set timewindow %s\n", err)
+		return
+	}
+	ts.DumpInTimezone("Europe/Madrid")
+
+	t0 = time.Date(2020, 4, 27, 9, 15, 0, 0, loc)
+	t1 = time.Date(2020, 4, 27, 9, 15, 0, 0, loc)
+
+	ts, err = win.GetTimeEvents(t0, t1)
+	if err != nil {
+		fmt.Printf("ERROR on set timewindow %s\n", err)
+		return
+	}
+	ts.DumpInTimezone("Europe/Madrid")
+
+	t0 = time.Date(2020, 4, 27, 9, 15, 1, 0, loc)
+	t1 = time.Date(2020, 4, 27, 9, 15, 1, 0, loc)
+
+	ts, err = win.GetTimeEvents(t0, t1)
+	if err != nil {
+		fmt.Printf("ERROR on set timewindow %s\n", err)
+		return
+	}
+	ts.DumpInTimezone("Europe/Madrid")
+
+	// Output:
+	// [INIT] Default VALUE: false
+	// [INIT] Default VALUE: true
+	// [0] TIME: 2020-04-27 09:15:00 +0200 CEST | VALUE: true
+	// [INIT] Default VALUE: true
+}


### PR DESCRIPTION
This PR tries to fix the USTs generation from given time events with
time less than 1h from the given TimeSlots boundaries

Now it supports a precision of milliseconds